### PR TITLE
Fix installation error and wrong man pages cmd

### DIFF
--- a/src/zsh_jupyter_kernel/config.py
+++ b/src/zsh_jupyter_kernel/config.py
@@ -144,7 +144,7 @@ config.update({
             "interrupt_mode": "signal",
         },
         'code_completness': {'cmd': "zsh -nc '{}'"},
-        'code_inspection': {'cmd': r"""zsh -c 'man -P "col -b" \\'{}\\''"""},
+        'code_inspection': {'cmd': r"""zsh -c 'man -P "col -b" \'{}\\''"""},
         'code_completion': {'cmd': config['module_dir'] + "/capture.zsh '{}'"},
             # https://github.com/danylo-dubinin/zsh-capture-completion
             # Thanks to https://github.com/Valodim/zsh-capture-completion

--- a/src/zsh_jupyter_kernel/install.py
+++ b/src/zsh_jupyter_kernel/install.py
@@ -20,7 +20,7 @@ def install_my_kernel_spec(user = True, prefix = None):
             user = user,
             prefix = prefix,
         )
-        print("Installed Z shell Jupyter kernel spec with prefix " + prefix)
+        print("Installed Z shell Jupyter kernel spec with prefix ", prefix)
 
 def _is_root():
     try:


### PR DESCRIPTION
Fixed error when installing without specifying `prefix`

Fixed command to retrieve man pages