### PR TITLE
Standardize shebang

### DIFF
--- a/src/zsh_jupyter_kernel/capture.zsh
+++ b/src/zsh_jupyter_kernel/capture.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # The MIT License (MIT)
 


### PR DESCRIPTION
Use `#!/usr/bin/env zsh` instead of `#!/bin/zsh`

Since zsh can be elsewhere than in /bin, we might as well trust env to use PATH rather than hard-coding the zsh path.

Typical error with `/bin/zsh` when zsh is installed in `/usr/local/bin`:
`zsh: /usr/home/xxx/.local/lib/python3.8/site-packages/zsh_jupyter_kernel/capture.zsh: bad interpreter: /bin/zsh: no such file or directory`